### PR TITLE
option for custom glm_path, closes #17

### DIFF
--- a/R/run_glm.R
+++ b/R/run_glm.R
@@ -62,6 +62,9 @@ glm.systemcall <- function(sim_folder, glm_path, verbose, system.args) {
   
   if(nchar(Sys.getenv("GLM_PATH")) > 0){
     glm_path <- Sys.getenv("GLM_PATH")
+    warning(paste0(
+      "Custom path to GLM executable set via 'GLM_PATH' environment variable as: ", 
+      glm_path))
   }
   
   origin <- getwd()

--- a/R/run_glm.R
+++ b/R/run_glm.R
@@ -59,6 +59,11 @@ run_glm <- function(sim_folder = '.', verbose=TRUE, system.args=character()) {
 
   
 glm.systemcall <- function(sim_folder, glm_path, verbose, system.args) {
+  
+  if(nchar(Sys.getenv("GLM_PATH")) > 0){
+    glm_path <- Sys.getenv("GLM_PATH")
+  }
+  
   origin <- getwd()
   setwd(sim_folder)
   

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,7 @@
 library(testthat)
 library(GLM3r)
 
+Sys.setenv("R_TESTS" = "") 
+
 test_check("GLM3r")
 


### PR DESCRIPTION
See #17. The change in `testthat.R` allows tests to pass when the glm_path is set using the `GLM_PATH` environment variable. https://github.com/r-lib/testthat/issues/144